### PR TITLE
Remove previous references to go-modifying links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@
 
 FROM golang AS build-env
 
-WORKDIR /go/src/github.com/phoenix-mstu/go-modifying-mqtt-proxy
+WORKDIR /go/src/github.com/phoenix-mstu/janus-mqtt-proxy
 ADD cmd cmd
 ADD internal internal
 
 RUN go get -d ./...
 RUN CGO_ENABLED=0 \
-    go install github.com/phoenix-mstu/go-modifying-mqtt-proxy/cmd/proxy
+    go install github.com/phoenix-mstu/janus-mqtt-proxy/cmd/proxy
 
 ################################################
 # making main image

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then you can run proxy: `./proxy basic.yaml`
 # More info
 
 - The most advanced sample config is located in 
-[sample_configs/my_wirenboard_to_homeassistant.yaml](https://github.com/phoenix-mstu/go-modifying-mqtt-proxy/blob/master/sample_configs/my_wirenboard_to_homeassistant.yaml).
+[sample_configs/my_wirenboard_to_homeassistant.yaml](https://github.com/phoenix-mstu/janus-mqtt-proxy/blob/master/sample_configs/my_wirenboard_to_homeassistant.yaml).
 Look there for more examples.
 
 - Article in English: https://medium.com/@phoenix.mstu/modifying-mqtt-proxy-bf6d8931ef60

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/phoenix-mstu/go-modifying-mqtt-proxy/internal/broker"
-	"github.com/phoenix-mstu/go-modifying-mqtt-proxy/internal/client"
-	"github.com/phoenix-mstu/go-modifying-mqtt-proxy/internal/config"
+	"github.com/phoenix-mstu/janus-mqtt-proxy/internal/broker"
+	"github.com/phoenix-mstu/janus-mqtt-proxy/internal/client"
+	"github.com/phoenix-mstu/janus-mqtt-proxy/internal/config"
 	"log"
 	"net"
 	"os"
@@ -25,7 +25,7 @@ func main() {
 	}
 
 	if configPath == "" {
-		println("Usage: go-modifying-mqtt-proxy /path/to/c.yaml")
+		println("Usage: janus-mqtt-proxy /path/to/c.yaml")
 		os.Exit(0)
 	}
 

--- a/internal/client/client_connection.go
+++ b/internal/client/client_connection.go
@@ -3,10 +3,10 @@ package client
 import (
 	"fmt"
 	"github.com/eclipse/paho.mqtt.golang/packets"
-	"github.com/phoenix-mstu/go-modifying-mqtt-proxy/internal/broker"
-	"github.com/phoenix-mstu/go-modifying-mqtt-proxy/internal/client_message_sender"
-	"github.com/phoenix-mstu/go-modifying-mqtt-proxy/internal/config"
-	"github.com/phoenix-mstu/go-modifying-mqtt-proxy/internal/subscriptions"
+	"github.com/phoenix-mstu/janus-mqtt-proxy/internal/broker"
+	"github.com/phoenix-mstu/janus-mqtt-proxy/internal/client_message_sender"
+	"github.com/phoenix-mstu/janus-mqtt-proxy/internal/config"
+	"github.com/phoenix-mstu/janus-mqtt-proxy/internal/subscriptions"
 	"log"
 	"net"
 )

--- a/internal/client/helpers.go
+++ b/internal/client/helpers.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/phoenix-mstu/go-modifying-mqtt-proxy/internal/subscriptions"
+	"github.com/phoenix-mstu/janus-mqtt-proxy/internal/subscriptions"
 )
 
 func filterForClient(filters []subscriptions.Filter, subs []subscription, topic string, payload []byte) (string, []byte, byte, bool) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"errors"
-	"github.com/phoenix-mstu/go-modifying-mqtt-proxy/internal/subscriptions"
+	"github.com/phoenix-mstu/janus-mqtt-proxy/internal/subscriptions"
 	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"log"


### PR DESCRIPTION
Repository used changed from go-modifying-mqtt-proxy to janus-mqtt-proxy therefore references to links containing old repository name needed change, especially for go imports.