### PR TITLE
Support for client IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea
 /bin
+/configs

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Modifying MQTT proxy
 
-With this service you can transform MQTT topics and their payload 
+With this service you can transform MQTT topics and their payload
 by specifying transformation rules.
 
-For example you have topics `/some/topic1` and `/some/another/topic2` on MQTT broker, 
-and you have a client which needs them to be `/root/topic1` and `/root/topic2`. 
+For example you have topics `/some/topic1` and `/some/another/topic2` on MQTT broker,
+and you have a client which needs them to be `/root/topic1` and `/root/topic2`.
 
 All you need is to create a yaml config with this rules:
 
@@ -15,7 +15,7 @@ broker_to_client:
   - topic: ^/some/topic1$
     template: '/root/topic1'
     val_map: {0: OFF, 1: ON}        # you can specify map to transform values
-  
+
   - topic: ^/some/another/([^/]*)$  # you can use regex
     template: '/root/{{.f1}}'       # and place an extracted part into template
 
@@ -35,15 +35,17 @@ And another yaml file with basic info:
 
 ```yaml
 broker_host: tcp://broker.host:1883
+broker_client_id: client_id
 broker_login: login
 broker_password: pass
 
 clients:
 
-  - login: some_login
+  - client_id: some_id
+    login: some_login
     password: some_pass
     filters_config: your_filters.yaml
-  
+
   # another client with no password
   - filters_config: another_filters.yaml
 ```
@@ -66,11 +68,11 @@ There are a few integration tests which check basic functionality. You can also 
 
 1. Clone the repository
 2. ```cd smoke_tests```
-3. ```/run_tests.sh```
+3. ```./run_tests.sh```
 
 # More info
 
-- The most advanced sample config is located in 
+- The most advanced sample config is located in
 [sample_configs/my_wirenboard_to_homeassistant.yaml](https://github.com/phoenix-mstu/janus-mqtt-proxy/blob/master/sample_configs/my_wirenboard_to_homeassistant.yaml).
 Look there for more examples.
 

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -37,7 +37,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	brokerConnection := broker.StartBrokerConnection(c.BrokerHost, c.BrokerLogin, c.BrokerPassword)
+	brokerConnection := broker.StartBrokerConnection(c.BrokerHost, c.BrokerClientID, c.BrokerLogin, c.BrokerPassword)
 
 	for {
 		clientConn, err := listener.Accept()

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -14,13 +14,14 @@ type BrokerConnection struct {
 	retainedKeeper *RetainedKeeper
 }
 
-func StartBrokerConnection(host, login, password string) *BrokerConnection {
+func StartBrokerConnection(host, client_id, login, password string) *BrokerConnection {
 	srvCon := BrokerConnection{
 		RWMutex: sync.RWMutex{},
 		retainedKeeper: newRetainedKeeper(),
 	}
 	srvCon.broker = mqtt.NewClient(mqtt.NewClientOptions().
 		AddBroker(host).
+		SetClientID(client_id).
 		SetUsername(login).
 		SetPassword(password).
 		SetDefaultPublishHandler(srvCon.messageHandler).

--- a/internal/client/client_connection.go
+++ b/internal/client/client_connection.go
@@ -17,7 +17,7 @@ type subscription struct {
 }
 
 type client struct {
-	cms			  *client_message_sender.ClientMessageSender
+	cms           *client_message_sender.ClientMessageSender
 	conn          net.Conn
 	configs       []config.CompiledFiltersConfig
 	brokerFilters []subscriptions.Filter
@@ -25,8 +25,8 @@ type client struct {
 
 	subscriptions []subscription
 	brokerClient  *broker.Client
-	isConnected bool
-	username string
+	isConnected   bool
+	username      string
 }
 
 func ServeClientConnection(conn net.Conn, configs []config.CompiledFiltersConfig, brokerClient *broker.Client) {
@@ -74,9 +74,9 @@ func (c *client) sendToBroker(MessageID uint16, topic string, qos byte, retained
 	}
 }
 
-func (c *client) login(username, password string) bool {
+func (c *client) login(client_id, username, password string) bool {
 	for _, conf := range c.configs {
-		if conf.Login == username && conf.Password == password {
+		if conf.ClientID == client_id && conf.Login == username && conf.Password == password {
 			c.isConnected = true
 			c.username = username
 			c.brokerFilters = conf.BrokerFilters
@@ -132,7 +132,7 @@ func (c *client) serveIncoming() {
 		case *packets.ConnectPacket:
 			c.printf("ConnectPacket, username: %v", packet.Username)
 			response := packets.NewControlPacket(packets.Connack).(*packets.ConnackPacket)
-			if c.login(packet.Username, string(packet.Password)) {
+			if c.login(packet.ClientIdentifier, packet.Username, string(packet.Password)) {
 				c.printf("Connected")
 				c.cms.SendPacket(response)
 			} else {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 )
 
 type CompiledFiltersConfig struct {
+	ClientID string
 	Login string
 	Password string
 	BrokerFilters []subscriptions.Filter
@@ -18,6 +19,7 @@ type CompiledFiltersConfig struct {
 }
 
 type CompiledConfig struct {
+	BrokerClientID string
 	BrokerHost string
 	BrokerLogin string
 	BrokerPassword string
@@ -32,6 +34,7 @@ func ReadConfigFile(filename string) *CompiledConfig {
 	}
 
 	res := CompiledConfig{
+		BrokerClientID: yamlMainConfig.BrokerClientID,
 		BrokerHost:     yamlMainConfig.BrokerHost,
 		BrokerLogin:    yamlMainConfig.BrokerLogin,
 		BrokerPassword: yamlMainConfig.BrokerPassword,
@@ -59,6 +62,7 @@ func ReadConfigFile(filename string) *CompiledConfig {
 		}
 
 		res.Clients = append(res.Clients, CompiledFiltersConfig{
+			ClientID:      cConfig.ClientID,
 			Login:         cConfig.Login,
 			Password:      cConfig.Password,
 			BrokerFilters: bf,

--- a/internal/config/yaml_files.go
+++ b/internal/config/yaml_files.go
@@ -15,9 +15,11 @@ type YamlFiltersConfig struct {
 
 type YamlMainConfig struct {
 	BrokerHost string `yaml:"broker_host"`
+	BrokerClientID string `yaml:"broker_client_id"`
 	BrokerLogin string `yaml:"broker_login"`
 	BrokerPassword string `yaml:"broker_password"`
 	Clients []struct{
+		ClientID string `yaml:"client_id"`
 		Login string
 		Password string
 		FiltersConfig string `yaml:"filters_config"`


### PR DESCRIPTION
Added optional field `client_id` and `broker_client_id` in configuration files for MQTT authentification.
Also did a few identation correction and added client identification in the README.md file.